### PR TITLE
Issue196 Dark mode

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Route } from 'react-router-dom'
 import { useQuery } from '@apollo/client'
 import { ME } from './graphql/queries'
@@ -6,11 +6,28 @@ import EditView from './components/EditView'
 import Header from './components/Header'
 import LoginForm from './components/LoginForm'
 import CallBack from './components/auth/CallBack'
-import { Toolbar } from '@material-ui/core'
 import RegisterForm from './components/RegisterForm'
+import { CssBaseline, Toolbar } from '@material-ui/core'
+import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles'
 
 const App = () => {
   const { data: user } = useQuery(ME)
+
+  const defaultColorTheme = 'light'
+  const [colorTheme, setColorTheme] = useState<'light' | 'dark'>(
+    defaultColorTheme
+  )
+
+  const toggleColorTheme = () => {
+    const newColorTheme = colorTheme === 'light' ? 'dark' : 'light'
+    setColorTheme(newColorTheme)
+  }
+
+  const theme = createMuiTheme({
+    palette: {
+      type: colorTheme,
+    },
+  })
 
   const logout = () => {
     localStorage.clear()
@@ -19,18 +36,26 @@ const App = () => {
 
   return (
     <div>
-      <Header user={user?.me} logout={logout} />
-      <div>
-        <Toolbar />
-        <Route path="/auth/github/callback">
-          <CallBack />
-        </Route>
-        <Route path="/edit">
-          <EditView />
-        </Route>
-        <Route exact path="/login" component={LoginForm} />
-        <Route exact path="/register" component={RegisterForm} />
-      </div>
+      <ThemeProvider theme={theme}>
+        <CssBaseline />
+        <Header
+          user={user?.me}
+          logout={logout}
+          colorTheme={colorTheme}
+          toggleColorTheme={toggleColorTheme}
+        />
+        <div>
+          <Toolbar />
+          <Route path="/auth/github/callback">
+            <CallBack />
+          </Route>
+          <Route path="/edit">
+            <EditView />
+          </Route>
+          <Route exact path="/login" component={LoginForm} />
+          <Route exact path="/register" component={RegisterForm} />
+        </div>
+      </ThemeProvider>
     </div>
   )
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,7 +35,7 @@ const App = () => {
   })
 
   const logout = () => {
-    localStorage.clear()
+    localStorage.removeItem('token')
     window.location.href = '/'
   }
 

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -8,32 +8,31 @@ import CallBack from './components/auth/CallBack'
 import RegisterForm from './components/RegisterForm'
 import { CssBaseline, Toolbar } from '@material-ui/core'
 import { createMuiTheme, ThemeProvider } from '@material-ui/core/styles'
+import { lightTheme, darkTheme } from './styles/themes'
 import RepositoriesView from './components/RepositoriesView'
 import MyLoginForm from './components/MyLoginForm'
 
 const App = () => {
   const { data: user } = useQuery(ME)
 
-  const defaultColorTheme = 'light'
-  const [colorTheme, setColorTheme] = useState<'light' | 'dark'>(() => {
-    const userColorTheme = localStorage.getItem('colorTheme')
-    if (userColorTheme === 'light' || userColorTheme === 'dark') {
-      return userColorTheme
+  const defaultTheme = 'light'
+  const [theme, setTheme] = useState<'light' | 'dark'>(() => {
+    const userTheme = localStorage.getItem('theme')
+    if (userTheme === 'light' || userTheme === 'dark') {
+      return userTheme
     }
-    return defaultColorTheme
+    return defaultTheme
   })
 
-  const toggleColorTheme = () => {
-    const newColorTheme = colorTheme === 'light' ? 'dark' : 'light'
-    setColorTheme(newColorTheme)
-    localStorage.setItem('colorTheme', newColorTheme)
+  const toggleTheme = () => {
+    const newTheme = theme === 'light' ? 'dark' : 'light'
+    setTheme(newTheme)
+    localStorage.setItem('theme', newTheme)
   }
 
-  const theme = createMuiTheme({
-    palette: {
-      type: colorTheme,
-    },
-  })
+  const appliedTheme = createMuiTheme(
+    theme === 'light' ? lightTheme : darkTheme
+  )
 
   const logout = () => {
     localStorage.removeItem('token')
@@ -42,13 +41,13 @@ const App = () => {
 
   return (
     <div>
-      <ThemeProvider theme={theme}>
+      <ThemeProvider theme={appliedTheme}>
         <CssBaseline />
         <Header
           user={user?.me}
           logout={logout}
-          colorTheme={colorTheme}
-          toggleColorTheme={toggleColorTheme}
+          theme={theme}
+          toggleTheme={toggleTheme}
         />
         <div>
           <Toolbar />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -14,13 +14,18 @@ const App = () => {
   const { data: user } = useQuery(ME)
 
   const defaultColorTheme = 'light'
-  const [colorTheme, setColorTheme] = useState<'light' | 'dark'>(
-    defaultColorTheme
-  )
+  const [colorTheme, setColorTheme] = useState<'light' | 'dark'>(() => {
+    const userColorTheme = localStorage.getItem('colorTheme')
+    if (userColorTheme === 'light' || userColorTheme === 'dark') {
+      return userColorTheme
+    }
+    return defaultColorTheme
+  })
 
   const toggleColorTheme = () => {
     const newColorTheme = colorTheme === 'light' ? 'dark' : 'light'
     setColorTheme(newColorTheme)
+    localStorage.setItem('colorTheme', newColorTheme)
   }
 
   const theme = createMuiTheme({

--- a/frontend/src/components/AuthenticateDialog.tsx
+++ b/frontend/src/components/AuthenticateDialog.tsx
@@ -1,19 +1,32 @@
 import React from 'react'
-import { Link } from 'react-router-dom'
+import { Link as RouterLink } from 'react-router-dom'
 import {
   Button,
+  createStyles,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
   Grid,
+  Link,
+  makeStyles,
 } from '@material-ui/core'
 
 interface Props {
   open: boolean
 }
 
+const stylesInUse = makeStyles((theme) =>
+  createStyles({
+    link: {
+      color: theme.palette.primary.light,
+    },
+  })
+)
+
 const AuthenticateDialog = ({ open }: Props) => {
+  const classes = stylesInUse()
+
   return (
     <Dialog open={open} aria-labelledby="auth-modal-title">
       <DialogTitle id="form-dialog-title">Please log in!</DialogTitle>
@@ -26,7 +39,9 @@ const AuthenticateDialog = ({ open }: Props) => {
       </DialogContent>
       <DialogActions>
         <Button>
-          <Link to="/login">Take me to login</Link>
+          <Link component={RouterLink} className={classes.link} to="/login">
+            Take me to login
+          </Link>
         </Button>
       </DialogActions>
     </Dialog>

--- a/frontend/src/components/AuthenticateDialog.tsx
+++ b/frontend/src/components/AuthenticateDialog.tsx
@@ -2,31 +2,19 @@ import React from 'react'
 import { Link as RouterLink } from 'react-router-dom'
 import {
   Button,
-  createStyles,
   Dialog,
   DialogActions,
   DialogContent,
   DialogTitle,
   Grid,
   Link,
-  makeStyles,
 } from '@material-ui/core'
 
 interface Props {
   open: boolean
 }
 
-const stylesInUse = makeStyles((theme) =>
-  createStyles({
-    link: {
-      color: theme.palette.primary.light,
-    },
-  })
-)
-
 const AuthenticateDialog = ({ open }: Props) => {
-  const classes = stylesInUse()
-
   return (
     <Dialog open={open} aria-labelledby="auth-modal-title">
       <DialogTitle id="form-dialog-title">Please log in!</DialogTitle>
@@ -39,7 +27,7 @@ const AuthenticateDialog = ({ open }: Props) => {
       </DialogContent>
       <DialogActions>
         <Button>
-          <Link component={RouterLink} className={classes.link} to="/login">
+          <Link component={RouterLink} to="/login">
             Take me to login
           </Link>
         </Button>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,6 +1,13 @@
 import React, { useState } from 'react'
-import { AppBar, Switch, Toolbar } from '@material-ui/core'
-import { Link } from 'react-router-dom'
+import {
+  AppBar,
+  createStyles,
+  Link,
+  makeStyles,
+  Switch,
+  Toolbar,
+} from '@material-ui/core'
+import { Link as RouterLink } from 'react-router-dom'
 import { UserType } from '../types'
 
 interface Props {
@@ -10,12 +17,21 @@ interface Props {
   toggleColorTheme: () => void
 }
 
-const padding = {
-  paddingRight: 5,
-}
+const stylesInUse = makeStyles((theme) =>
+  createStyles({
+    appBar: {
+      zIndex: 1250,
+    },
+    link: {
+      paddingRight: 10,
+      color: theme.palette.primary.main,
+    },
+  })
+)
 
 const Header = ({ user, logout, colorTheme, toggleColorTheme }: Props) => {
   const [switchChecked, setSwitchChecked] = useState(colorTheme === 'dark')
+  const classes = stylesInUse()
 
   const handleSwitchToggle = () => {
     setSwitchChecked(!switchChecked)
@@ -23,26 +39,31 @@ const Header = ({ user, logout, colorTheme, toggleColorTheme }: Props) => {
   }
 
   return (
-    <AppBar position="fixed" color="default" style={{ zIndex: 1250 }}>
+    <AppBar position="fixed" color="default" className={classes.appBar}>
       <Toolbar>
-        <Link style={padding} to="/">
+        <Link component={RouterLink} className={classes.link} to="/">
           Main menu
         </Link>
-        <Link style={padding} to="/edit">
+        <Link component={RouterLink} className={classes.link} to="/edit">
           Edit view
         </Link>
         {!user && (
-          <Link style={padding} to="/login">
+          <Link component={RouterLink} className={classes.link} to="/login">
             Login
           </Link>
         )}
         {!user && (
-          <Link style={padding} to="/register">
+          <Link component={RouterLink} className={classes.link} to="/register">
             Register
           </Link>
         )}
         {user && (
-          <Link style={padding} to="/" onClick={logout}>
+          <Link
+            component={RouterLink}
+            className={classes.link}
+            to="/"
+            onClick={logout}
+          >
             {user.username} - logout
           </Link>
         )}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -13,8 +13,8 @@ import { UserType } from '../types'
 interface Props {
   user: UserType
   logout: () => void
-  colorTheme: string
-  toggleColorTheme: () => void
+  theme: string
+  toggleTheme: () => void
 }
 
 const stylesInUse = makeStyles((theme) =>
@@ -24,18 +24,17 @@ const stylesInUse = makeStyles((theme) =>
     },
     link: {
       paddingRight: 10,
-      color: theme.palette.primary.main,
     },
   })
 )
 
-const Header = ({ user, logout, colorTheme, toggleColorTheme }: Props) => {
-  const [switchChecked, setSwitchChecked] = useState(colorTheme === 'dark')
+const Header = ({ user, logout, theme, toggleTheme }: Props) => {
+  const [switchChecked, setSwitchChecked] = useState(theme === 'dark')
   const classes = stylesInUse()
 
   const handleSwitchToggle = () => {
     setSwitchChecked(!switchChecked)
-    toggleColorTheme()
+    toggleTheme()
   }
 
   return (

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,18 +1,27 @@
-import React from 'react'
-import { AppBar, Toolbar } from '@material-ui/core'
+import React, { useState } from 'react'
+import { AppBar, Switch, Toolbar } from '@material-ui/core'
 import { Link } from 'react-router-dom'
 import { UserType } from '../types'
 
 interface Props {
   user: UserType
   logout: () => void
+  colorTheme: string
+  toggleColorTheme: () => void
 }
 
 const padding = {
   paddingRight: 5,
 }
 
-const Header = ({ user, logout }: Props) => {
+const Header = ({ user, logout, colorTheme, toggleColorTheme }: Props) => {
+  const [switchChecked, setSwitchChecked] = useState(colorTheme === 'dark')
+
+  const handleSwitchToggle = () => {
+    setSwitchChecked(!switchChecked)
+    toggleColorTheme()
+  }
+
   return (
     <AppBar position="fixed" color="default" style={{ zIndex: 1250 }}>
       <Toolbar>
@@ -37,6 +46,12 @@ const Header = ({ user, logout }: Props) => {
             {user.username} - logout
           </Link>
         )}
+        <Switch
+          checked={switchChecked}
+          onChange={handleSwitchToggle}
+          color="primary"
+          inputProps={{ 'aria-label': 'primary checkbox' }}
+        />
       </Toolbar>
     </AppBar>
   )

--- a/frontend/src/components/MonacoEditor.tsx
+++ b/frontend/src/components/MonacoEditor.tsx
@@ -3,7 +3,7 @@ import Editor from '@monaco-editor/react'
 import { useMutation, useQuery } from '@apollo/client'
 import { ME, REPO_STATE } from '../graphql/queries'
 import { SAVE_CHANGES } from '../graphql/mutations'
-import { Button } from '@material-ui/core'
+import { Button, useTheme } from '@material-ui/core'
 import SaveDialog from './SaveDialog'
 import AuthenticateDialog from './AuthenticateDialog'
 import { RepoStateQueryResult } from '../types'
@@ -42,6 +42,8 @@ const MonacoEditor = ({ content, filename }: Props) => {
       refetchQueries: [{ query: REPO_STATE }],
     }
   )
+
+  const theme = useTheme()
 
   const valueGetter = useRef<Getter | null>(null)
 
@@ -94,6 +96,7 @@ const MonacoEditor = ({ content, filename }: Props) => {
       <Editor
         height="75vh"
         language="javascript"
+        theme={theme.palette.type}
         value={content}
         editorDidMount={handleEditorDidMount}
       />

--- a/frontend/src/components/RegisterForm.tsx
+++ b/frontend/src/components/RegisterForm.tsx
@@ -11,11 +11,10 @@ import { useMutation } from '@apollo/client'
 import { REGISTER } from '../graphql/mutations'
 import RegisterSchema from './RegisterSchema'
 
-const stylesInUse = makeStyles(() =>
+const stylesInUse = makeStyles((theme) =>
   createStyles({
     root: {
       maxWidth: '500px',
-      color: 'white',
       display: 'block',
       margin: '0 auto',
     },
@@ -27,9 +26,9 @@ const stylesInUse = makeStyles(() =>
     registerButton: {
       marginTop: '30px',
     },
-    title: { textAlign: 'left', color: 'black' },
-    successMessage: { color: 'green' },
-    errorMessage: { color: 'red' },
+    title: { textAlign: 'left' },
+    successMessage: { color: theme.palette.success.main },
+    errorMessage: { color: theme.palette.error.main },
   })
 )
 

--- a/frontend/src/components/auth/GitHubAuthBtn.tsx
+++ b/frontend/src/components/auth/GitHubAuthBtn.tsx
@@ -19,6 +19,7 @@ const GitHubAuthBtn = () => {
     <div>
       <Button
         variant="contained"
+        color="primary"
         startIcon={<GitHubIcon />}
         onClick={btnClickHandler}
       >

--- a/frontend/src/styles/themes.ts
+++ b/frontend/src/styles/themes.ts
@@ -1,0 +1,21 @@
+import { ThemeOptions } from '@material-ui/core'
+
+// Currently using some of the baseline colors from https://material.io/design/color/dark-theme.html
+
+export const lightTheme: ThemeOptions = {
+  palette: {
+    type: 'light',
+    primary: { main: '#6200EE' },
+    secondary: { main: '#03DAC6' },
+    error: { main: '#B00020' },
+  },
+}
+
+export const darkTheme: ThemeOptions = {
+  palette: {
+    type: 'dark',
+    primary: { main: '#BB86FC' },
+    secondary: { main: '#03DAC6' },
+    error: { main: '#CF6679' },
+  },
+}


### PR DESCRIPTION
Closes #196 

- Added support for dark mode and the ability to change between it and light mode
    - Uses the default themes for Monaco Editor. For Material-UI mostly defaults with some colors copied from Material Design [guidelines](https://material.io/design/color/dark-theme.html) for improved legibility
- Selected theme is saved in localStorage to avoid resetting it between reloads

![dark_mode](https://user-images.githubusercontent.com/37346883/100065880-006da300-2e3d-11eb-8744-1492c898770b.png)
