### PR TITLE
Issue218 show GitHub status

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -47,7 +47,7 @@
     "dev": "ts-node-dev --respawn --transpile-only --exit-child src/",
     "start": "NODE_ENV=production node ./build/index.js",
     "test": "cross-env NODE_ENV=test jest --verbose --runInBand",
-    "test:watch": "jest --watchAll",
+    "test:watch": "jest --watchAll --runInBand",
     "test-ci": "cross-env NODE_ENV=test jest --verbose --runInBand",
     "pretest": "DATABASE_URL=postgres://test:test@localhost:5432/test node-pg-migrate -m ./src/db/migrations up",
     "migrate": "node-pg-migrate",

--- a/backend/src/schema/schema.ts
+++ b/backend/src/schema/schema.ts
@@ -6,6 +6,7 @@ const Query = `
     type Query {
         githubLoginUrl: String!
         me: User
+        isGithubConnected: Boolean!
         getRepoState(url: String): RepoState!
         cloneRepository(url: String!): String
         currentToken: String

--- a/backend/src/schema/user.ts
+++ b/backend/src/schema/user.ts
@@ -45,6 +45,13 @@ const resolvers = {
     ): UserType | undefined => {
       return context.currentUser
     },
+    isGithubConnected: (
+      _root: unknown,
+      _args: unknown,
+      context: AppContext
+    ): boolean => {
+      return !!context.githubToken
+    },
     githubLoginUrl: (): string => {
       const cbUrl = config.GITHUB_CB_URL || ''
       const clientID = config.GITHUB_CLIENT_ID || ''

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "@apollo/client": "^3.2.1",
     "@material-ui/core": "^4.11.0",
-    "@material-ui/icons": "^4.9.1",
+    "@material-ui/icons": "^4.11.2",
     "@material-ui/lab": "^4.0.0-alpha.56",
     "@monaco-editor/react": "^3.6.2",
     "@testing-library/jest-dom": "^4.2.4",

--- a/frontend/src/components/MonacoEditor.tsx
+++ b/frontend/src/components/MonacoEditor.tsx
@@ -2,13 +2,14 @@ import React, { useRef, useState } from 'react'
 import Editor from '@monaco-editor/react'
 import { monaco } from '@monaco-editor/react'
 import { useMutation, useQuery } from '@apollo/client'
-import { ME, REPO_STATE } from '../graphql/queries'
+import { IS_GH_CONNECTED, ME, REPO_STATE } from '../graphql/queries'
 import { SAVE_CHANGES } from '../graphql/mutations'
-import { Button, useTheme } from '@material-ui/core'
+import { Button, Tooltip, useTheme } from '@material-ui/core'
 import SaveDialog from './SaveDialog'
 import AuthenticateDialog from './AuthenticateDialog'
-import { RepoStateQueryResult } from '../types'
+import { isGithubConnectedResult, RepoStateQueryResult } from '../types'
 import { initMonaco } from '../utils/monacoInitializer'
+import { GitHub } from '@material-ui/icons'
 
 interface Props {
   content: string | undefined
@@ -24,9 +25,33 @@ interface DialogError {
   message: string
 }
 
+const GHConnected = ({ isGithubConnected }: { isGithubConnected: boolean }) => {
+  const githubConnected = () => {
+    return (
+      <Tooltip title="gitHub is connected. Saving will push to github">
+        <GitHub />
+      </Tooltip>
+    )
+  }
+
+  return (
+    <span
+      style={{
+        marginLeft: '1rem',
+        verticalAlign: 'middle',
+      }}
+    >
+      {isGithubConnected ? githubConnected() : 'Github is not connected'}
+    </span>
+  )
+}
+
 const MonacoEditor = ({ content, filename }: Props) => {
   const [dialogOpen, setDialogOpen] = useState(false)
   const branchState = useQuery<RepoStateQueryResult>(REPO_STATE)
+  const { data: GHConnectedQuery } = useQuery<isGithubConnectedResult>(
+    IS_GH_CONNECTED
+  )
   const currentBranch = branchState.data?.repoState.currentBranch || ''
   const [dialogError, setDialogError] = useState<DialogError | undefined>(
     undefined
@@ -117,20 +142,27 @@ const MonacoEditor = ({ content, filename }: Props) => {
           error={dialogError}
         />
 
-        <Button
-          color="primary"
-          variant="contained"
-          disabled={
-            userQueryLoading ||
-            !!userQueryError ||
-            mutationSaveLoading ||
-            !user.me ||
-            branchState.loading
-          }
-          onClick={handleSaveButton}
-        >
-          Save
-        </Button>
+        <div>
+          <Button
+            color="primary"
+            variant="contained"
+            disabled={
+              userQueryLoading ||
+              !!userQueryError ||
+              mutationSaveLoading ||
+              !user.me ||
+              branchState.loading
+            }
+            onClick={handleSaveButton}
+          >
+            Save
+          </Button>
+          {GHConnectedQuery && (
+            <GHConnected
+              isGithubConnected={GHConnectedQuery.isGithubConnected}
+            />
+          )}
+        </div>
       </div>
       <div style={{ fontSize: 14, marginTop: 5, marginBottom: 5 }}>
         {(!user || !user.me) && 'Please login to enable saving'}

--- a/frontend/src/components/MonacoEditor.tsx
+++ b/frontend/src/components/MonacoEditor.tsx
@@ -28,7 +28,7 @@ interface DialogError {
 const GHConnected = ({ isGithubConnected }: { isGithubConnected: boolean }) => {
   const githubConnected = () => {
     return (
-      <Tooltip title="gitHub is connected. Saving will push to github">
+      <Tooltip title="GitHub is connected. Saving will push to GitHub">
         <GitHub />
       </Tooltip>
     )
@@ -41,7 +41,7 @@ const GHConnected = ({ isGithubConnected }: { isGithubConnected: boolean }) => {
         verticalAlign: 'middle',
       }}
     >
-      {isGithubConnected ? githubConnected() : 'Github is not connected'}
+      {isGithubConnected ? githubConnected() : 'GitHub is not connected'}
     </span>
   )
 }

--- a/frontend/src/graphql/queries.ts
+++ b/frontend/src/graphql/queries.ts
@@ -16,6 +16,12 @@ export const REPO_STATE = gql`
   }
 `
 
+export const IS_GH_CONNECTED = gql`
+  query {
+    isGithubConnected
+  }
+`
+
 export const CLONE_REPO = gql`
   query {
     cloneRepo: cloneRepository(

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -7,6 +7,10 @@ export interface FileListQueryResult {
   files: File[]
 }
 
+export interface isGithubConnectedResult {
+  isGithubConnected: boolean
+}
+
 export interface RepoStateQueryResult {
   repoState: {
     currentBranch: string

--- a/frontend/yarn.lock
+++ b/frontend/yarn.lock
@@ -1402,10 +1402,10 @@
     react-is "^16.8.0"
     react-transition-group "^4.4.0"
 
-"@material-ui/icons@^4.9.1":
-  version "4.9.1"
-  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.9.1.tgz#fdeadf8cb3d89208945b33dbc50c7c616d0bd665"
-  integrity sha512-GBitL3oBWO0hzBhvA9KxqcowRUsA0qzwKkURyC8nppnC3fw54KPKZ+d4V1Eeg/UnDRSzDaI9nGCdel/eh9AQMg==
+"@material-ui/icons@^4.11.2":
+  version "4.11.2"
+  resolved "https://registry.yarnpkg.com/@material-ui/icons/-/icons-4.11.2.tgz#b3a7353266519cd743b6461ae9fdfcb1b25eb4c5"
+  integrity sha512-fQNsKX2TxBmqIGJCSi3tGTO/gZ+eJgWmMJkgDiOfyNaunNaxcklJQFaFogYcFl0qFuaEz1qaXYXboa/bUXVSOQ==
   dependencies:
     "@babel/runtime" "^7.4.4"
 


### PR DESCRIPTION
![img](https://i.imgur.com/kLH4nwi.png)

![img2](https://i.imgur.com/F6vLwly.png)

Closes #218 
Backend changes: 
- New graphql query `isGithubConnected: Boolean!` which returns true or false based on if `context.user` has githubToken or not.
- Two tests for the query

Frontend changes:
- Updated @material-ui/icons
- Added `isGIthubConnected` type and query
- Add new `GHConnected` -component which is located and used in `MonacoEditor.tsx`